### PR TITLE
Fixed bug in URL reference index

### DIFF
--- a/examples/unordered_list.py
+++ b/examples/unordered_list.py
@@ -11,7 +11,8 @@ def minimal():
 
     * This is the first ``item`` in the unordered list. It is a long line that will be wrapped
     * This is the second item in the unordered list.
-
+    * An URL link `first link <https://example.com>`_
+    * An URL link `second link <https://example.com>`_
     """
     pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sphinx-click-rst-to-ansi-formatter"
-version = "0.1.0"
+version = "0.1.2"
 description = ""
 authors = ["Håkon Hægland <hakon.hagland@gmail.com>"]
 readme = "README.md"

--- a/src/sphinx_click/rst_to_ansi_formatter/formatter.py
+++ b/src/sphinx_click/rst_to_ansi_formatter/formatter.py
@@ -107,7 +107,7 @@ class PlainTextVisitor(docutils.nodes.NodeVisitor):
             self.urls.append(url)
             idx = len(self.urls)
         else:
-            idx = self.urls.index(url)
+            idx = self.urls.index(url) + 1
         # Replace the URL with a placeholder
         replacement_txt = f"[{idx}]"
         return replacement_txt


### PR DESCRIPTION
When two or more identical URLs references were used, the indices of all reference except the first one were incorrect.