### PR TITLE
Refactored PlainTextVisitor

### DIFF
--- a/src/sphinx_click/rst_to_ansi_formatter/colors.py
+++ b/src/sphinx_click/rst_to_ansi_formatter/colors.py
@@ -2,6 +2,7 @@ from colorama import Fore, Style
 
 from .types import ColorDict
 
+
 class Colors:
     def __init__(self, colors: ColorDict | None = None):
         if colors is None:


### PR DESCRIPTION
Refactored PlainTextVisitor to use `io.StringIO` as buffer. This should improve efficiency. We do not need the list of string buffers anyway. A single string buffer is enough.